### PR TITLE
Add documentation to the `runCLI` function

### DIFF
--- a/lib/extract/runCLI.ts
+++ b/lib/extract/runCLI.ts
@@ -9,7 +9,9 @@ import { TypeScriptSourceFile } from "./TypeScriptSourceFile.ts";
  * @param rootDir the root directory of the project. Usually `import.meta.dirname`.
  *
  * @example Running from the configuration options
+ * ```ts
  * import.meta.main && await runCLI(options, import.meta.dirname);
+ * ```
  */
 export async function runCLI({
   pattern = "**/*.{ts,tsx}",


### PR DESCRIPTION
Since this function is usually called from the application's config file, it is also considered to be a library function.

Therefore, it requires documentation.
