### PR TITLE
Add `LocalizedHttpException` for nice, localized error handling

### DIFF
--- a/lib/hono/LocalizedHttpException.ts
+++ b/lib/hono/LocalizedHttpException.ts
@@ -2,7 +2,7 @@ import { HTTPException } from "@hono/hono/http-exception";
 import type { LazyLocalizedString } from "./LazyLocalizedString.ts";
 
 /**
- * Options for creating a LocalizedError.
+ * Options for creating a LocalizedHttpException.
  */
 export interface LocalizedHttpExceptionOptions {
   /**

--- a/lib/hono/LocalizedHttpException.ts
+++ b/lib/hono/LocalizedHttpException.ts
@@ -89,7 +89,7 @@ export class LocalizedHttpException extends HTTPException {
     public readonly options: LocalizedHttpExceptionOptions = {},
   ) {
     super(options.status ?? 500, {
-      ...options,
+      cause: options.cause,
     });
     this.message = options.technicalMessage ? `<${this.errorId}> ${options.technicalMessage}` : `<${this.errorId}>`;
   }

--- a/lib/hono/LocalizedHttpException.ts
+++ b/lib/hono/LocalizedHttpException.ts
@@ -1,0 +1,128 @@
+import { HTTPException } from "@hono/hono/http-exception";
+import type { LazyLocalizedString } from "./LazyLocalizedString.ts";
+
+/**
+ * Options for creating a LocalizedError.
+ */
+export interface LocalizedHttpExceptionOptions {
+  /**
+   * Technical message for this error. Logged for debugging purposes.
+   * This is the only message guaranteed to be logged.
+   */
+  readonly technicalMessage?: string;
+  /**
+   * HTTP status code to be used for this error.
+   * Defaults to 500 (Internal Server Error).
+   */
+  readonly status?: HTTPException["status"];
+  /**
+   * Optional cause of this error. Logged for debugging purposes.
+   */
+  readonly cause?: unknown;
+  /**
+   * Localized title for this error. Shown to the user.
+   */
+  readonly localizedTitle?: LazyLocalizedString;
+  /**
+   * Localized message for this error. Shown to the user.
+   */
+  readonly localizedMessage?: LazyLocalizedString;
+}
+
+/**
+ * An HTTP exception that supports localization.
+ *
+ * Contains both technical details for logging and user-friendly localized messages.
+ *
+ * Use {@link fromCause} to convert arbitrary errors / exceptions into LocalizedHttpExceptions.
+ *
+ * By logging the LocalizedHttpException, the technical message and cause are preserved for debugging purposes.
+ * Logs and user messages can be correlated using the {@link errorId}.
+ *
+ * See {@link LocalizedHttpExceptionOptions} for details on the available options.
+ *
+ * @example
+ *
+ * ```ts
+ * throw new LocalizedHttpException({
+ *   technicalMessage: "Database connection failed",
+ *   status: 503,
+ *   localizedTitle: lt`Service Unavailable`,
+ *   localizedMessage: lt`The service is currently unavailable. Please try again later.`,
+ * });
+ * ```
+ *
+ * @example
+ *
+ * ```ts
+ * router.onError((err, c) => {
+ *   const localizedError = LocalizedHttpException.fromCause(err);
+ *   console.error("[router]", localizedError);
+ *   c.status(localizedError.status || 500);
+ *   return c.render(
+ *     <>
+ *       <h1>{ t(localizedError.options.localizedTitle ?? lt`Unknown Error`)}</h1>
+ *       <p>{ t(localizedError.options.localizedMessage ?? lt`An unexpected error occurred while processing your request.`) }</p>
+ *       <p>{ t(`Please specify the following error ID when contacting support:`) }</p>
+ *       <pre><code>{ localizedError.errorId }</code></pre>
+ *     </>
+ *   );
+ * });
+ * ```
+ */
+export class LocalizedHttpException extends HTTPException {
+  /**
+   * Unique error ID for this exception instance.
+   * Used for correlating logs with user reports.
+   *
+   * Format: ISO timestamp + "-" + first 8 characters of a UUIDv4
+   */
+  public readonly errorId: string = new Date().toISOString() + "-" +
+    crypto.randomUUID().substring(0, 8);
+
+  /**
+   * Creates a new LocalizedHttpException.
+   * Use {@link fromCause} to convert arbitrary errors / exceptions into LocalizedHttpExceptions.
+   * @param options the options for the error. See {@link LocalizedHttpExceptionOptions} for details
+   */
+  constructor(
+    public readonly options: LocalizedHttpExceptionOptions = {},
+  ) {
+    super(options.status ?? 500, {
+      ...options,
+    });
+    this.message = `<${this.errorId}> ${options.technicalMessage}`;
+  }
+
+  /**
+   * Converts an arbitrary error into a LocalizedHttpException.
+   *
+   * Useful for error handlers that can receive any kind of error.
+   * After conversion, the returned LocalizedHttpException can be used to
+   * retrieve localized messages for the user.
+   *
+   * By logging the returned LocalizedHttpException, the technical message
+   * and cause are preserved for debugging purposes.
+   * Logs and user messages can be correlated using the {@link errorId}.
+   * @param error the original error
+   * @returns a corresponding {@link LocalizedHttpException}
+   */
+  static fromCause(
+    error: unknown,
+  ): LocalizedHttpException {
+    if (error instanceof LocalizedHttpException) {
+      return error;
+    }
+    if (error instanceof HTTPException) {
+      return new LocalizedHttpException({
+        technicalMessage: error.message,
+        status: error.status,
+        cause: error,
+      });
+    }
+    return new LocalizedHttpException({
+      technicalMessage: "Unknown error (see cause for details)",
+      cause: error,
+    });
+  }
+}

--- a/lib/hono/LocalizedHttpException.ts
+++ b/lib/hono/LocalizedHttpException.ts
@@ -91,7 +91,7 @@ export class LocalizedHttpException extends HTTPException {
     super(options.status ?? 500, {
       ...options,
     });
-    this.message = `<${this.errorId}> ${options.technicalMessage}`;
+    this.message = options.technicalMessage ? `<${this.errorId}> ${options.technicalMessage}` : `<${this.errorId}>`;
   }
 
   /**

--- a/lib/hono/LocalizedHttpException.ts
+++ b/lib/hono/LocalizedHttpException.ts
@@ -91,7 +91,9 @@ export class LocalizedHttpException extends HTTPException {
     super(options.status ?? 500, {
       cause: options.cause,
     });
-    this.message = options.technicalMessage ? `<${this.errorId}> ${options.technicalMessage}` : `<${this.errorId}>`;
+    this.message = options.technicalMessage
+      ? `<${this.errorId}> ${options.technicalMessage}`
+      : `<${this.errorId}>`;
   }
 
   /**

--- a/lib/mod.ts
+++ b/lib/mod.ts
@@ -7,3 +7,7 @@ export { runCLI } from "./extract/runCLI.ts";
 export { useLocale } from "./hono/useLocale.ts";
 export type { LocalizedStringValue } from "./hono/LocalizedStringValue.ts";
 export type { LazyLocalizedString } from "./hono/LazyLocalizedString.ts";
+export {
+  LocalizedHttpException,
+  type LocalizedHttpExceptionOptions,
+} from "./hono/LocalizedHttpException.ts";


### PR DESCRIPTION
This PR introduces LocalizedHttpException, a custom error class that extends Hono's HTTPException to provide localized error messages while preserving technical details for debugging. The implementation allows errors to carry both developer-facing technical messages and user-facing localized content, with a unique error ID for correlation between logs and user reports.

Key Changes:

Added LocalizedHttpException class with support for localized titles/messages and technical logging
Implemented fromCause() static method for converting arbitrary errors to LocalizedHttpException
Added global error handler in the example app demonstrating proper error handling with localization
Created E2E tests validating localized error responses across different languages
